### PR TITLE
[36일차] 신영제_BOJ_코테뿌셔_29

### DIFF
--- a/day36/BOJ_6087_레이저통신/BOJ_6087_레이저통신_신영제_검색활용.java
+++ b/day36/BOJ_6087_레이저통신/BOJ_6087_레이저통신_신영제_검색활용.java
@@ -1,0 +1,106 @@
+package AlgoStudy;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_6087_레이저통신 {
+
+   public static class laser implements Comparable<laser> {
+      int x;
+      int y;
+      int dir;
+      int cnt;
+
+      public laser(int x, int y, int dir, int cnt) {
+         this.x = x;
+         this.y = y;
+         this.dir = dir;
+         this.cnt = cnt;
+      }
+
+      @Override
+      public int compareTo(laser o) {
+         return this.cnt - o.cnt;
+      }
+   }
+
+   static int W, H;
+
+   static char[][] map;
+   static int[][] visit;
+
+   static int[] dx = { -1, 0, 1, 0 };
+   static int[] dy = { 0, 1, 0, -1 };
+
+   static laser start, end;
+
+   public static void main(String[] args) throws IOException {
+      BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+      StringTokenizer st = null;
+
+      st = new StringTokenizer(br.readLine());
+      W = Integer.parseInt(st.nextToken());
+      H = Integer.parseInt(st.nextToken());
+
+      map = new char[H][W];
+      visit = new int[H][W];
+
+      for (int i = 0; i < H; i++) {
+         String t = br.readLine();
+
+         for (int j = 0; j < W; j++) {
+            map[i][j] = t.charAt(j);
+            visit[i][j] = Integer.MAX_VALUE;
+
+            if (map[i][j] == 'C') {
+               if (start == null) {
+                  start = new laser(i, j, -1, 0);
+               } else {
+                  end = new laser(i, j, -1, 0);
+               }
+            }
+         }
+      }
+
+      bfs();
+      System.out.println(visit[end.x][end.y]);
+   }
+
+   private static void bfs() {
+      PriorityQueue<laser> pq = new PriorityQueue<>();
+
+      pq.add(start);
+      visit[start.x][start.y] = 0;
+
+      while (!pq.isEmpty()) {
+         laser cur = pq.poll();
+         
+         if (cur.x == end.x && cur.y == end.y)
+            break;
+
+         for (int k = 0; k < 4; k++) {
+            int nx = cur.x + dx[k];
+            int ny = cur.y + dy[k];
+            int ncnt = cur.cnt;
+
+            if (nx < 0 || ny < 0 || nx >= H || ny >= W || map[nx][ny] == '*') {
+               continue;
+            }
+
+            if (cur.dir != -1 && cur.dir != k) {
+               ncnt++;               
+            }
+            
+            
+            if (visit[nx][ny] >= ncnt) {
+               visit[nx][ny] = ncnt;
+               pq.add(new laser(nx, ny, k, ncnt));
+            }
+         }
+      }
+   }
+
+}


### PR DESCRIPTION
0. 방향 전환 시 갱신 + 다익스트라 사용 인터넷 검색 
1. laser class를 사용하여 시작 레이저와 도착 레이저를 저장 합니다.
2. 처음에는 모든 방향으로 통신이 가능 하므로 -1로 저장 합니다.
3. 거울의 수를 갱신할 visit배열에 갱신이 계속되기 때문에
   방문 배열을 작성하지 않고 무한대로 초기화합니다. 
4. 우선순위 큐를 사용 하여 거울 수가 더 적은 경우 갱신하여 큐에 추가합니다.
5. -1 이거나 현재 방향과 탐색방향이 다른경우 거울을 추가해야 하므로 거울 수를 더합니다.

내 생각 : 
1. 출발, 도착 C를 기준으로 모든 영역 탐색하여 최소값 식별합니다. 
2. 거울의 갯수를 추가할 방법이 떠오르지 않았습니다. 
3. BFS 탐색을 통해 모든 방향을 탐색 해보고자 했습니다.
4. ( 2 )의 구현이 생각이 안나 접근 방법을 본 후 다익스트라 학습 후 인터넷 검색하여 문제 이해를 취지로 학습 하였습니다.
